### PR TITLE
Size and density as optional parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,30 +7,30 @@ convert_image.sh - Convert image
 
 Usage: convert_image.sh -i input_file -o output_file [options] [convert options]
 
-Options:
--h, --help               Show brief help.
--v, --verbose            Verbose output.
--i, --input              Input file or URI. Mandatory.
--o, --output             Output file. Mandatory. Set "-" to send directly to standard
-                         output.
--t, --target-profile     Color profile file to apply. Default "./profiles/sRGB.icm".
--gp, --generic-cmyk      Generic profile to use when a CMYK image without profile is
-                         given. Default "./profiles/Apple_Generic_CMYK_Profile.icc".
--p, --page, --layer      Select input page or layer (PDF or PSD). Default "0".
--fp, --ps-formats        Formats to be interpreted as postscript graphic. Comma separated
-                         list. Those will be checked (with ps2pdf) if are pure vector
-                         graphic. Default "EPDF,EPI,EPS,EPSF,EPSI,PDF,PDFA,PS".
--fv, --vector-formats    Formats to be interpreted as vector graphic. comma separated
-                         list. Default "MSVG,SVG,SVGZ,AI,PCT,PICT".
--s, --size               Thumbnail size. Empty for no processing. Default "".
--d, --density            Density. Empty for no processing.  Default "".
--q, --quality            JPEG quality. Default "80".
--b, --background         Set background of image, might not be shown (depends on alpha).
-                         Default "white".
--a, --alpha              Modify alpha channel of an image. Default "remove".
--lt, --logentries-token  Logentries token. If not given no logging performed.
--lu, --logentries-url    Logentries url. Default "data.logentries.com".
--lp, --logentries-port   Logentries port. Default "10000".
+-h, --help                  Show brief help.
+-v, --verbose               Verbose output.
+-i, --input                 Input file or URI. Mandatory.
+-o, --output                Output file. Mandatory. Set "-" to send directly to standard
+                            output.
+-pt, --target-profile       Color profile file to apply. Default "./profiles/sRGB.icm".
+-psc, --source-profile-cmyk Generic profile to use when a CMYK image without profile is
+                            given. Default "./profiles/Apple_Generic_CMYK_Profile.icc".
+-p, --page, --layer         Select input page or layer (PDF or PSD). Default "0".
+-fp, --ps-formats           Formats to be interpreted as postscript graphic. Comma
+                            separated list. Those will be checked (with ps2pdf) if are
+                            pure vector graphic.
+                            Default "EPDF,EPI,EPS,EPSF,EPSI,PDF,PDFA,PS".
+-fv, --vector-formats       Formats to be interpreted as vector graphic. comma separated
+                            list. Default "MSVG,SVG,SVGZ,AI,PCT,PICT".
+-s, --size                  Thumbnail size. Empty for no processing. Default "".
+-d, --density               Density. Empty for no processing.  Default "".
+-q, --quality               JPEG quality. Default "80".
+-b, --background            Set background of image, might not be shown (depends on
+                            alpha). Default "white".
+-a, --alpha                 Modify alpha channel of an image. Default "remove".
+-lt, --logentries-token     Logentries token. If not given no logging performed.
+-lu, --logentries-url       Logentries url. Default "data.logentries.com".
+-lp, --logentries-port      Logentries port. Default "10000".
 
 convert options: see 'convert --help'
 ```

--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ Options:
                          graphic. Default "EPDF,EPI,EPS,EPSF,EPSI,PDF,PDFA,PS".
 -fv, --vector-formats    Formats to be interpreted as vector graphic. comma separated
                          list. Default "MSVG,SVG,SVGZ,AI,PCT,PICT".
--s, --size               Thumbnail size. Default "200x200>".
--d, --density            Density. Default "72".
+-s, --size               Thumbnail size. Empty for no processing. Default "".
+-d, --density            Density. Empty for no processing. Default "".
 -q, --quality            JPEG quality. Default "80".
 -b, --background         Set background of image, might not be shown (depends on alpha).
                          Default "white".

--- a/convert_image.sh
+++ b/convert_image.sh
@@ -3,7 +3,7 @@
 
 # Set defaults
 function set_defaults() {
-    TARGET_PROFILE_FILE="./profiles/sRGB.icm"
+    TARGET_PROFILE_FILE="$(dirname ${BASH_SOURCE})/profiles/sRGB.icm"
     SIZE=""
     PAGE="0"
     DENSITY=""
@@ -38,7 +38,7 @@ function usage() {
 	echo "-v, --verbose               Verbose output." # Is more a script debug mode
  	echo "-i, --input                 Input file or URI. Mandatory."
  	echo "-o, --output                Output file. Mandatory. Set \"-\" to send directly to standard output."
- 	echo "-t, --target-profile        Color profile file to apply. Default \"${TARGET_PROFILE_FILE}\"."
+ 	echo "-pt, --target-profile       Color profile file to apply. Default \"${TARGET_PROFILE_FILE}\"."
  	echo "-psc, --source-profile-cmyk Generic profile to use when a CMYK image without profile is given."
  	echo "                            Default \"${SOURCE_PROFILE_CMYK}\"."
  	echo "-p, --page, --layer         Select input page or layer (PDF or PSD). Default \"${PAGE}\"."

--- a/convert_image.sh
+++ b/convert_image.sh
@@ -4,9 +4,9 @@
 # Set defaults
 function set_defaults() {
     TARGET_PROFILE_FILE="./profiles/sRGB.icm"
-    SIZE="200x200>"
+    SIZE=""
     PAGE="0"
-    DENSITY="72"
+    DENSITY=""
     QUALITY="80"
     BACKGROUND="white"
     ALPHA="remove"
@@ -47,8 +47,8 @@ function usage() {
  	echo "                         Default \"${POSTSCRIPT_FORMATS}\"."
  	echo "-fv, --vector-formats    Formats to be interpreted as vector graphic. comma separated list."
  	echo "                         Default \"${VECTOR_FORMATS}\"."
- 	echo "-s, --size               Thumbnail size. Default \"${SIZE}\"."                         # http://www.imagemagick.org/script/command-line-processing.php#geometry
- 	echo "-d, --density            Density. Default \"${DENSITY}\"."                             # http://www.imagemagick.org/script/command-line-options.php#density
+ 	echo "-s, --size               Thumbnail size. Empty for no processing. Default \"${SIZE}\"."                         # http://www.imagemagick.org/script/command-line-processing.php#geometry
+ 	echo "-d, --density            Density. Empty for no processing. Default \"${DENSITY}\"."                             # http://www.imagemagick.org/script/command-line-options.php#density
  	echo "-q, --quality            JPEG quality. Default \"${QUALITY}\"."
  	echo "-b, --background         Set background of image, might not be shown (depends on alpha)."
  	echo "                         Default \"${BACKGROUND}\"."
@@ -310,6 +310,16 @@ if [ ! ${IS_VECTOR} -eq 0 ]; then
          if [ $1 -gt $2 ]; then echo $1; else echo $2; fi
     }
 
+    if [[ "AAA${DENSITY}AAA" == "AAAAAA" ]]; then
+        DENSITY="72"
+        echo "Vector graphic image needs a target density, but none defined. Using \"${DENSITY}\"."
+    fi
+
+    if [[ "AAA${SIZE}AAA" == "AAAAAA" ]]; then
+        SIZE="300x300>"
+        echo "Vector graphic image needs a target size, but none defined. Using \"${SIZE}\"."
+    fi
+
     DEST_SIZE_X=`expr match "${SIZE}" '\([0-9]\+\).*$'`           # OR ${SIZE%x*}
     DEST_SIZE_Y=`expr match "${SIZE}" '[0-9]\+x\?\([0-9]\+\).*$'` # @todo: refactor eg "72" returns "2" .. ok for now, because we need the max only
     DEST_MAX=$(max ${DEST_SIZE_X} ${DEST_SIZE_Y})
@@ -349,8 +359,15 @@ fi
 COMMAND+=" ${INPUT_FILE}[${PAGE}]"
 COMMAND+=" -profile ${TARGET_PROFILE_FILE}"
 COMMAND+=" -background ${BACKGROUND} -alpha ${ALPHA}"
-COMMAND+=" -thumbnail ${SIZE}"
-COMMAND+=" -density ${DENSITY}"
+
+if [[ ! "AAA${SIZE}AAA" == "AAAAAA" ]]; then
+    COMMAND+=" -thumbnail ${SIZE}"
+fi
+
+if [[ ! "AAA${DENSITY}AAA" == "AAAAAA" ]]; then
+    COMMAND+=" -density ${DENSITY}"
+fi
+
 COMMAND+=" -quality ${QUALITY}"
 COMMAND+=" ${REMAINING}"
 COMMAND+=" ${OUTPUT_FILE}"


### PR DESCRIPTION
Permit image processing without size or density processing, made it as default.

If a full vector graphic image is provided without target density or size a default is applied (density "72" and size "300x300>")
